### PR TITLE
nix: switch to building with libc++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,17 +1,11 @@
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_C_COMPILER clang)
 set(CMAKE_CXX_COMPILER clang++)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-
-# ASIO currently doesn't detect coroutine support
-# since it only checks for the existence of the
-# removed <experimental/coroutine> header.
-# https://github.com/chriskohlhoff/asio/pull/1145
-add_compile_definitions(ASIO_HAS_CO_AWAIT ON)
 
 project(
   exchange

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1692799911,
-        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1694522937,
-        "narHash": "sha256-aH++76tY6w70A1mggtyNDYiYA27wZkETCAqOKs9sxV8=",
+        "lastModified": 1699033847,
+        "narHash": "sha256-3hofIt1uQZOeleumNvbFA6VwsIMria0Hinaqb7mZGf4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ba33a55822e463e1bfb3a3c69e694c8600ff7142",
+        "rev": "275ec9436ab6ca6b6d3c4f6424fc8f75f23db7f0",
         "type": "github"
       },
       "original": {

--- a/matcher/include/ring_buffer.hpp
+++ b/matcher/include/ring_buffer.hpp
@@ -208,8 +208,8 @@ template <class RingBuf> class batch_iterate {
 public:
   batch_iterate(RingBuf &buf, std::shared_ptr<cursor> cons_curs,
                 typename RingBuf::size_type max_batch_size)
-      : buf_{buf}, curs_{std::move(cons_curs)}, max_batch_size_{
-                                                    max_batch_size} {}
+      : buf_{buf}, curs_{std::move(cons_curs)},
+        max_batch_size_{max_batch_size} {}
 
   batch_iterator<RingBuf> begin() noexcept {
     return {buf_, curs_, max_batch_size_};

--- a/nix/clang.nix
+++ b/nix/clang.nix
@@ -1,7 +1,18 @@
+{ vanillaNixpkgs }:
 final: prev:
 rec {
-  llvm = prev.llvm_15;
-  llvmPackages = prev.llvmPackages_15;
+  inherit (vanillaNixpkgs)
+    bison
+    boost-build
+    cmake
+    expect
+    libxslt
+    libxml2
+    ninja
+    openssl
+    python3;
+  llvm = prev.llvm_16;
+  llvmPackages = prev.llvmPackages_16;
   clangStdenv = llvmPackages.libcxxStdenv;
   clang-tools = prev.clang-tools.override { inherit llvmPackages; };
   lldb = llvmPackages.lldb;


### PR DESCRIPTION
- Bump clang to version 16
- Use clang stdlib:
  - Has support for std::expectation
  - Removes need for asio coroutine workaround