### PR TITLE
nix: use binary cache when building

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,10 @@ jobs:
     - uses: cachix/install-nix-action@v22
       with:
         github_access_token: ${{ secrets.GITHUB_TOKEN }}
-
+    - uses: cachix/cachix-action@v12
+      with:
+        name: walton98
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - name: Fetch Nix Dependencies
       run: nix develop
 


### PR DESCRIPTION
Uses cachix to pull/push built binaries.