### PR TITLE
server: add sequencing backlog queue

### DIFF
--- a/matcher/include/request.hpp
+++ b/matcher/include/request.hpp
@@ -78,7 +78,7 @@ class queuer {
 public:
   queuer(ring_buffer::producer<RingBuf> prod) : prod_{std::move(prod)} {}
 
-  void operator()(const matcher_proto::Action &action);
+  void operator()(const matcher_proto::Envelope &);
 
 private:
   ring_buffer::producer<RingBuf> prod_;

--- a/matcher/src/main.cpp
+++ b/matcher/src/main.cpp
@@ -20,8 +20,7 @@ auto create_consumer(asio::io_context &ioc, auto &prod) {
   // Create handler layers
   auto queuer = matcher::queuer{prod};
   // TODO: pass in next seqnum from restore
-  auto sequencer = server::sequencer<decltype(queuer), matcher_proto::Action>{
-      std::move(queuer)};
+  auto sequencer = server::sequencer<decltype(queuer)>{std::move(queuer)};
   auto decoder = server::decoder{std::move(sequencer)};
 
   return server::consumer{ioc, multicast_port, multicast_host,

--- a/matcher/src/request.cpp
+++ b/matcher/src/request.cpp
@@ -29,9 +29,9 @@ auto handle_message(const matcher_proto::Action &action)
 
 } // namespace
 
-void queuer::operator()(const matcher_proto::Action &action) {
+void queuer::operator()(const matcher_proto::Envelope &envelope) {
   // TODO: handle unexpected
-  auto parsed_action = handle_message(action).value();
+  auto parsed_action = handle_message(envelope.action()).value();
 
   // send to ring buffer
   prod_.produce_one(parsed_action);

--- a/matcher/test/matcher_client.py
+++ b/matcher/test/matcher_client.py
@@ -12,8 +12,10 @@ class MatcherClient:
         self._mcast_port = mcast_port
         self._seq_num = 0
 
-    def send_request(self, action: Action) -> None:
-        env = Envelope(action=action, seq_num=self._seq_num)
+    def send_request(self, action: Action, seq_num: int | None = None) -> None:
+        if seq_num is None:
+            seq_num = self._seq_num
+            self._seq_num += 1
+        env = Envelope(action=action, seq_num=seq_num)
         msg = env.SerializeToString()
         self._sock.sendto(msg, (self._mcast_grp, self._mcast_port))
-        self._seq_num += 1

--- a/matcher/test/test_matcher.py
+++ b/matcher/test/test_matcher.py
@@ -36,3 +36,9 @@ def test_create_book(matcher_client: MatcherClient) -> None:
 
 def test_snapshot(matcher_client: MatcherClient) -> None:
     snapshot(matcher_client)
+
+
+def test_seq_nums(matcher_client: MatcherClient) -> None:
+    action = create_book(420)
+    for i in reversed(range(32)):
+        matcher_client.send_request(action, seq_num=i)

--- a/packages/server/include/server/layers.hpp
+++ b/packages/server/include/server/layers.hpp
@@ -2,6 +2,7 @@
 #define SERVER_LAYERS_HPP
 
 #include <cstdint>
+#include <queue>
 #include <string>
 #include <utility>
 
@@ -10,27 +11,54 @@
 
 namespace server {
 
-template <typename F, typename T> class sequencer {
-public:
-  sequencer(F &&f, uint64_t next_seq_num = 0)
-      : f_{std::move(f)}, next_seq_num_{next_seq_num} {}
+bool cmp(const matcher_proto::Envelope &lhs,
+         const matcher_proto::Envelope &rhs) {
+  return lhs.seq_num() > rhs.seq_num();
+}
 
-  void operator()(uint64_t seq_num, const T &payload) {
-    if (seq_num == next_seq_num_) {
-      spdlog::debug("Got message with seqnum: {}", seq_num);
-      f_(payload);
-      // TODO: drain from queue
-      ++next_seq_num_;
+template <typename F> class sequencer {
+public:
+  using Envelope = matcher_proto::Envelope;
+
+  sequencer(F &&f, uint64_t next_seq_num = 0)
+      : f_{std::move(f)}, next_seq_num_{next_seq_num}, backlog_{cmp} {}
+
+  void operator()(const Envelope &env) {
+    if (env.seq_num() == next_seq_num_) {
+      execute(env);
+      drain_queue();
+    } else if (env.seq_num() > next_seq_num_) {
+      spdlog::debug("Adding message to backlog: got {}, expected {}",
+                    env.seq_num(), next_seq_num_);
+      backlog_.push(env);
+      if (backlog_.size() > 16) {
+        spdlog::warn("Queue is filling up, current size: {}", backlog_.size());
+      }
     } else {
-      spdlog::warn("Skipping message: got {}, expected {}", seq_num,
-                   next_seq_num_);
-      // TODO: add to queue
+      spdlog::debug("Skipping old message: got {}, expected {}", env.seq_num(),
+                    next_seq_num_);
     }
   }
 
 private:
   F f_;
   uint64_t next_seq_num_;
+  std::priority_queue<Envelope, std::vector<Envelope>,
+                      std::function<bool(Envelope, Envelope)>>
+      backlog_;
+
+  void execute(const matcher_proto::Envelope &env) {
+    spdlog::debug("Executing message with seqnum: {}", env.seq_num());
+    f_(env);
+    ++next_seq_num_;
+  }
+
+  void drain_queue() {
+    while (!backlog_.empty() && backlog_.top().seq_num() == next_seq_num_) {
+      execute(backlog_.top());
+      backlog_.pop();
+    }
+  }
 };
 
 template <typename F> class decoder {
@@ -43,7 +71,7 @@ public:
       spdlog::warn("Could not parse message");
       return;
     }
-    f_(envelope.seq_num(), envelope.action());
+    f_(envelope);
   }
 
 private:


### PR DESCRIPTION
When receiving requests, keep track of the next expected sequence number. Then if the request has:
- lower sequence number then ignore
- higher sequence number then add to priority queue (ordered by seq. num)
- matching sequence number then process this message and pull any consecutive messages out of priority queue

Closes #21