### PR TITLE
network: replace use_awaitable with deferred

### DIFF
--- a/packages/network/include/network/producer.hpp
+++ b/packages/network/include/network/producer.hpp
@@ -1,10 +1,11 @@
 #include <print>
-#include <vector>
+#include <span>
 
+#include <asio/as_tuple.hpp>
+#include <asio/awaitable.hpp>
+#include <asio/deferred.hpp>
 #include <asio/io_context.hpp>
 #include <asio/ip/udp.hpp>
-#include <asio/redirect_error.hpp>
-#include <asio/use_awaitable.hpp>
 
 namespace network {
 
@@ -15,11 +16,9 @@ public:
         endpoint_{*asio::ip::udp::resolver(ioc).resolve(asio::ip::udp::v4(),
                                                         host, port)} {}
 
-  asio::awaitable<void> produce(std::vector<char> data) {
-    asio::error_code ec;
-    co_await socket_.async_send_to(
-        asio::buffer(data), endpoint_,
-        asio::redirect_error(asio::use_awaitable, ec));
+  asio::awaitable<void> produce(std::span<char> data) {
+    auto [ec, _] = co_await socket_.async_send_to(
+        asio::buffer(data), endpoint_, asio::as_tuple(asio::deferred));
     if (ec) {
       std::println("Error processing message: {}", ec.message());
     }


### PR DESCRIPTION
- use `asio::deferred` in place of `asio::use_awaitable` (prevents the allocation of a coroutine frame)
- use `asio::as_tuple` in place of `asio::redirect_error`
- replace `cout` with `println` (to be changed to use actual logging library at some point)

Closes #75